### PR TITLE
[github] suppress failing sapling website steps on fork

### DIFF
--- a/.github/workflows/sapling-website-deploy.yml
+++ b/.github/workflows/sapling-website-deploy.yml
@@ -2,6 +2,8 @@ name: Publish https://sapling-scm.com
 
 on:
   workflow_dispatch:
+  # only run on prs if not a fork
+  if: ${{ !github.event.pull_request.head.repo.fork }}
   pull_request:
 
 jobs:


### PR DESCRIPTION
Clean up sapling PRs form forks slightly by removing always failing job