### PR TITLE
reviewstack: fix verify addons/ folder github ci

### DIFF
--- a/.github/workflows/sapling-addons.yml
+++ b/.github/workflows/sapling-addons.yml
@@ -14,6 +14,8 @@ jobs:
     container:
       image: ${{ format('ghcr.io/{0}/build_ubuntu_20_04:latest', github.repository) }}
     steps:
+      - name: Install fb-watchman
+        run: curl -fsSL https://github.com/facebook/watchman/releases/download/v2023.09.18.00/watchman_ubuntu20.04_v2023.09.18.00.deb -o watchman.deb && apt -y -f install ./watchman.deb
       - name: Checkout Code
         uses: actions/checkout@v3
       - name: Grant Access

--- a/addons/isl-server/src/Repository.ts
+++ b/addons/isl-server/src/Repository.ts
@@ -8,7 +8,6 @@
 import type {CodeReviewProvider} from './CodeReviewProvider';
 import type {ServerSideTracker} from './analytics/serverSideTracker';
 import type {Logger} from './logger';
-import type {ExecaError} from 'execa';
 import type {
   CommitInfo,
   CommitPhaseType,
@@ -44,7 +43,7 @@ import {WatchForChanges} from './WatchForChanges';
 import {DEFAULT_DAYS_OF_COMMITS_TO_LOAD, ErrorShortMessages} from './constants';
 import {GitHubCodeReviewProvider} from './github/githubCodeReviewProvider';
 import {isGithubEnterprise} from './github/queryGraphQL';
-import {handleAbortSignalOnProcess, serializeAsyncCall} from './utils';
+import {handleAbortSignalOnProcess, isExecaError, serializeAsyncCall} from './utils';
 import execa from 'execa';
 import {CommandRunner} from 'isl/src/types';
 import os from 'os';
@@ -838,8 +837,9 @@ async function runCommand(
   const result = execa(command, args, options);
 
   let timedOut = false;
+  let timeoutId: NodeJS.Timeout | undefined;
   if (timeout > 0) {
-    const timeoutId = setTimeout(() => {
+    timeoutId = setTimeout(() => {
       result.kill('SIGTERM', {forceKillAfterTimeout: 5_000});
       logger.error(`Timed out waiting for ${command} ${args[0]} to finish`);
       timedOut = true;
@@ -862,11 +862,9 @@ async function runCommand(
       }
     }
     throw err;
+  } finally {
+    clearTimeout(timeoutId);
   }
-}
-
-function isExecaError(err: unknown): err is ExecaError {
-  return typeof err === 'object' && err != null && 'exitCode' in err;
 }
 
 export const __TEST__ = {

--- a/addons/isl-server/src/github/githubCodeReviewProvider.ts
+++ b/addons/isl-server/src/github/githubCodeReviewProvider.ts
@@ -115,6 +115,7 @@ export class GitHubCodeReviewProvider implements CodeReviewProvider {
 
   public dispose() {
     this.diffSummaries.removeAllListeners();
+    this.triggerDiffSummariesFetch.dispose();
   }
 
   public getSummaryName(): string {

--- a/addons/isl-server/src/github/queryGraphQL.ts
+++ b/addons/isl-server/src/github/queryGraphQL.ts
@@ -4,9 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-
-import type {ExecaError} from 'execa';
-
+import {isExecaError} from '../utils';
 import execa from 'execa';
 
 export default async function queryGraphQL<TData, TVariables>(
@@ -38,8 +36,17 @@ export default async function queryGraphQL<TData, TVariables>(
   args.push('--hostname', hostname);
   args.push('-f', `query=${query}`);
 
-  const {stdout} = await execa('gh', args, {stdout: 'pipe', stderr: 'pipe'}).catch(
-    (error: ExecaError & {code?: string}) => {
+  try {
+    const {stdout} = await execa('gh', args, {stdout: 'pipe', stderr: 'pipe'});
+    const json = JSON.parse(stdout);
+
+    if (Array.isArray(json.errors)) {
+      return Promise.reject(`Error: ${json.errors[0].message}`);
+    }
+
+    return json.data;
+  } catch (error: unknown) {
+    if (isExecaError(error)) {
       if (error.code === 'ENOENT' || error.code === 'EACCES') {
         // `gh` not installed on path
         throw new Error(`GhNotInstalledError: ${(error as Error).stack}`);
@@ -47,16 +54,9 @@ export default async function queryGraphQL<TData, TVariables>(
         // `gh` CLI exit code 4 => authentication issue
         throw new Error(`NotAuthenticatedError: ${(error as Error).stack}`);
       }
-      throw error;
-    },
-  );
-  const json = JSON.parse(stdout);
-
-  if (Array.isArray(json.errors)) {
-    return Promise.reject(`Error: ${json.errors[0].message}`);
+    }
+    throw error;
   }
-
-  return json.data;
 }
 
 /**

--- a/addons/isl-server/src/utils.ts
+++ b/addons/isl-server/src/utils.ts
@@ -165,6 +165,6 @@ export function parseExecJson<T>(
     });
 }
 
-export function isExecaError(s: unknown): s is ExecaError {
-  return s != null && typeof s === 'object' && 'stderr' in s;
+export function isExecaError(s: unknown): s is ExecaError & {code?: string} {
+  return s != null && typeof s === 'object' && 'exitCode' in s;
 }

--- a/addons/shared/debounce.ts
+++ b/addons/shared/debounce.ts
@@ -9,6 +9,7 @@ export type DebouncedFunction<Args extends Array<unknown>> = {
   (...args: Args): void;
   reset: () => void;
   isPending: () => boolean;
+  dispose: () => void;
 };
 
 /**
@@ -52,6 +53,7 @@ export function debounce<Args extends Array<unknown>>(
     if (leading) {
       callback = function () {
         shouldCallLeading = true;
+        clearTimeout(timeout);
         timeout = undefined;
       };
 
@@ -66,11 +68,13 @@ export function debounce<Args extends Array<unknown>>(
     } else {
       debouncer.reset();
       callback = function () {
+        clearTimeout(timeout);
         timeout = undefined;
         func.apply(context, args);
       };
     }
 
+    clearTimeout(timeout);
     timeout = setTimeout(callback, wait);
   }
 
@@ -78,6 +82,11 @@ export function debounce<Args extends Array<unknown>>(
     clearTimeout(timeout);
     timeout = undefined;
     shouldCallLeading = true;
+  };
+
+  debouncer.dispose = function () {
+    clearTimeout(timeout);
+    timeout = undefined;
   };
 
   debouncer.isPending = function () {

--- a/addons/verify-addons-folder.py
+++ b/addons/verify-addons-folder.py
@@ -45,8 +45,9 @@ async def verify(*, use_vendored_grammars=False):
         verify_shared(),
         verify_textmate(),
         verify_isl(),
-        verify_reviewstack(use_vendored_grammars=use_vendored_grammars),
     )
+    # shared depends on reviewstack generated textmate grammars, so can't run concurrently without flakiness
+    await verify_reviewstack(use_vendored_grammars=use_vendored_grammars)
 
 
 async def verify_prettier():


### PR DESCRIPTION
The container image was missing the gh command line, resulting in CI errors.   Then found it was intermittently failing due to logging after finish, added jest options.

Test plan:

Run the ci.  Before, broken with:
```
Error: Unhandled error. (Error: GhNotInstalledError: Error: Command failed with ENOENT: gh api graphql -f searchQuery=repo:facebook/sapling is:pr author:@me -F numToFetch=100 --hostname github.com -f query=
    query YourPullRequestsQuery($searchQuery: String!, $numToFetch: Int!) {
  search(query: $searchQuery, type: ISSUE, first: $numToFetch) {
    nodes {
      ... on PullRequest {
```

Then found it was intermittently failing due to logging after finish with:
```
  ●  Cannot log after tests are done. Did you forget to wait for something async in your test?
    Attempted to log "Watchman:  Watchman was not found in PATH.  See https://facebook.github.io/watchman/docs/install.html for installation instructions".

      at console.error (../node_modules/@jest/console/build/BufferedConsole.js:163:10)
      at spawnError (node_modules/fb-watchman/index.js:173:13)
      at ChildProcess.<anonymous> (node_modules/fb-watchman/index.js:198:5)
```

Given watch was disabled, added the --no-watchman --detectOpenHandles options as well.

After, can see the setTimeout is causing issues in test