### PR TITLE
run edenfs integration tests in github CI

### DIFF
--- a/.github/workflows/edenfs_linux.yml
+++ b/.github/workflows/edenfs_linux.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: Show disk space at start
@@ -27,9 +27,9 @@ jobs:
     - name: Update system package info
       run: sudo apt-get update
     - name: Install system deps
-      run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --no-tests --recursive eden
+      run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive eden
     - name: Install packaging system deps
-      run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --no-tests --recursive patchelf
+      run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive patchelf
     - name: Install Rust Stable
       uses: dtolnay/rust-toolchain@stable
     - name: Fetch lmdb
@@ -84,6 +84,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests re2
     - name: Fetch rocksdb
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests rocksdb
+    - name: Fetch python-setuptools
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests python-setuptools
     - name: Fetch sqlite3
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests sqlite3
     - name: Fetch zlib
@@ -184,6 +186,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests re2
     - name: Build rocksdb
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests rocksdb
+    - name: Build python-setuptools
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests python-setuptools
     - name: Build sqlite3
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests sqlite3
     - name: Build zlib
@@ -230,16 +234,20 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fb303
     - name: Build rust-shed
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests rust-shed
+    - name: Build sapling
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. --free-up-disk --no-tests sapling
     - name: Build edencommon
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests edencommon
     - name: Build eden
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests --src-dir=. eden  --project-install-prefix eden:/usr/local
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-deps --src-dir=. eden  --project-install-prefix eden:/usr/local
     - name: Copy artifacts
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --strip --src-dir=. eden _artifacts/linux  --project-install-prefix eden:/usr/local --final-install-prefix /usr/local
     - uses: actions/upload-artifact@v4
       with:
         name: eden
         path: _artifacts
+    - name: Test eden
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages test --num-jobs 16 --src-dir=. eden  --project-install-prefix eden:/usr/local
     - name: Show disk space at end
       if: always()
       run: df -h

--- a/build/fbcode_builder/manifests/eden
+++ b/build/fbcode_builder/manifests/eden
@@ -8,7 +8,7 @@ shipit_fbcode_builder = true
 repo_url = https://github.com/facebook/sapling.git
 
 [github.actions]
-run_tests = off
+run_tests = on
 
 [sandcastle]
 run_tests = off
@@ -54,6 +54,10 @@ libcurl
 python
 # TODO: teach getdeps to compile lmdb on Windows.
 lmdb
+
+[dependencies.test=on]
+# sapling CLI is needed to run the tests
+sapling
 
 [shipit.pathmap.fb=on]
 # for internal builds that use getdeps

--- a/eden/fs/cli/main.py
+++ b/eden/fs/cli/main.py
@@ -28,7 +28,15 @@ from typing import Dict, List, Optional, Set, Tuple, Type
 
 import thrift.transport
 
-from cli.py import par_telemetry
+try:
+    from cli.py import par_telemetry
+except ImportError:
+    # in OSS define a stub
+    class ParTelemetryStub:
+        def set_sample_rate(self, automation):
+            pass
+    par_telemetry = ParTelemetryStub()
+
 from eden.fs.cli.buck import get_buck_command, run_buck_command
 from eden.fs.cli.config import HG_REPO_TYPES
 from eden.fs.cli.telemetry import TelemetrySample


### PR DESCRIPTION
Summary:

Now that we have sapling manifest we can start to run EdenFS tests in github CI

Added a stub for missing import of cli.py par_telemetry which was failing tests.

Fixed getdeps support for test only dependencies in github action generation, then regenerated CI actions with:

```
./build/fbcode_builder/getdeps.py --allow-system-packages generate-github-actions --free-up-disk --os-type=linux --src-dir=. --output-dir=.github/workflows --job-name "EdenFS " --job-file-prefix=edenfs_ eden --num-jobs=16  --project-install-prefix sapling:/usr/local
```

Test Plan:

enter toolbox:
```
toolbox enter ubuntu-toolbox-22.04
```

build sapling and eden:
``
./build/fbcode_builder/getdeps.py install-system-deps --recursive eden ./build/fbcode_builder/getdeps.py build --allow-system-packages --no-facebook-internal --src-dir=. sapling ./build/fbcode_builder/getdeps.py build --allow-system-packages --no-facebook-internal --src-dir=. eden
```

run eden tests locally:
```
./build/fbcode_builder/getdeps.py test --allow-system-packages --no-facebook-internal --num-jobs=8 --src-dir=. eden
```