### PR TITLE
getdeps: add xxhash ubuntu and homebrew packages and fix actions generation

### DIFF
--- a/.github/workflows/edenfs_linux.yml
+++ b/.github/workflows/edenfs_linux.yml
@@ -50,6 +50,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests glog
     - name: Fetch googletest
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests googletest
+    - name: Fetch xxhash
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests xxhash
     - name: Fetch zstd
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zstd
     - name: Fetch boost
@@ -148,6 +150,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests glog
     - name: Build googletest
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests googletest
+    - name: Build xxhash
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests xxhash
     - name: Build zstd
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests zstd
     - name: Build boost
@@ -237,4 +241,5 @@ jobs:
         name: eden
         path: _artifacts
     - name: Show disk space at end
+      if: always()
       run: df -h

--- a/build/fbcode_builder/manifests/xxhash
+++ b/build/fbcode_builder/manifests/xxhash
@@ -8,6 +8,13 @@ sha256 = baee0c6afd4f03165de7a4e67988d16f0f2b257b51d0e3cb91909302a26a79c4
 [rpms]
 xxhash-devel
 
+[debs]
+libxxhash-dev
+xxhash
+
+[homebrew]
+xxhash
+
 [build.not(os=windows)]
 builder = make
 subdir = xxHash-0.8.2


### PR DESCRIPTION
Summary:
EdenFS build on github CI was failing with missing xxhash include: https://github.com/facebook/sapling/actions/runs/11311478649/job/31457761727#step:108:3838

Add package mappings to the xxhash manifest

When I went to regenerate the github actions found I'd previously introduced a bug in the actions generation with a mis-merged run_tests check.  Fix it and regenerate

Test Plan:

Build locally on ubuntu-22.04 toolbox to repro issue, its broken,
```
./build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. eden
```

Install the packages:
```
./build/fbcode_builder/getdeps.py install-system-deps --recursive eden
```

Run again, it builds:
```
./build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. eden
```

Regenerate the github workflow:
```
 ./build/fbcode_builder/getdeps.py --allow-system-packages generate-github-actions --no-tests --free-up-disk --os-type=linux --src-dir=. --output-dir=.github/workflows --job-name "EdenFS " --job-file-prefix=edenfs_ eden --num-jobs=8  --project-install-prefix sapling:/usr/local
```