### PR TITLE
fix sapling getdeps macOS

### DIFF
--- a/build/fbcode_builder/manifests/python
+++ b/build/fbcode_builder/manifests/python
@@ -2,7 +2,9 @@
 name = python
 
 [homebrew]
-python@3.8
+# python 3.12 on brew doesn't install all the symlinks. 
+# 3.13 does but our pyo3 is too old for it
+python@3.11
 
 [rpms]
 python3

--- a/build/fbcode_builder/manifests/sapling
+++ b/build/fbcode_builder/manifests/sapling
@@ -60,7 +60,7 @@ fb303
 fbthrift
 rust-shed
 
-[dependencies.test=on]
+[dependencies.all(test=on,not(os=darwin))]
 hexdump
 
 [dependencies.not(os=windows)]

--- a/eden/scm/Makefile
+++ b/eden/scm/Makefile
@@ -68,7 +68,7 @@ COMPILERFLAG_tmp_${COMPILER} ?= -c $(COMPILER)
 COMPILERFLAG=${COMPILERFLAG_tmp_${COMPILER}}
 
 MAKE_PID := $(shell echo $$PPID)
-JOBS := $(shell ps T | sed -n 's%.*$(MAKE_PID).*$(MAKE).* \(-j\|--jobs=\) *\([0-9][0-9]*\).*%\2%p')
+JOBS := $(shell ps T | sed -n -Ee 's%.*$(MAKE_PID).*$(MAKE).* (-j|--jobs=) *([0-9][0-9]*).*%\2%p')
 
 # Mac Big Sur doesn't find the standard library without this.
 export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
@@ -259,7 +259,6 @@ test-getdeps:
 		fi; \
 		$$PYTHON_SYS_EXECUTABLE run-tests.py -j $(JOBS) --getdeps-build --with-hg="$(PREFIX)/bin/$(HGNAME)" $$GETDEPS_TEST_FILTER; \
 		status=$$?; \
-		# stop if all good \
 		if [ $$status = 0 ]; then echo "passed on try $$try"; exit 0; fi; \
 	done; \
 	exit $$status


### PR DESCRIPTION
Summary:
   * filter out hexdump dependency on macos, its a system util there
   * set brew dependency to python@3.11, not @3.8.  Our pyo3 dependency is too old for python@3.13, and python@3.12 doesn't install all the symlinks necessary.
   * Makefile fixes:
      * macOS's old make doesn't like comment in continued shell line, remove it
      * fix sed job count parsing on macOS make

After this I can build and run cli without "unknown python exception", and I can start the test suite (although its very slow compared to my linux server, not got a full run yet).

Test Plan:

**local build**
install brew dependencies:
```
./build/fbcode_builder/getdeps.py install-system-deps build sapling
```
build
```
./build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. sapling
```
test binary works without "unknown python exception":
```
Mon 21 Oct 2024 18:46:05 BST [Exit: 0 0] ahornby@ahornby-mbp:~/local/sapling-sl/eden/scm/tests
$ /Users/ahornby/.scratch/UsersZahornbyZlocalZsapling-sl/fbcode_builder_getdeps/installed/sapling/bin/sl --help | head -4
Mon 21 Oct 2024 18:46:07 BST
Sapling SCM

sl COMMAND [OPTIONS]
```

**run tests**
Before, failed to run any tests

After, runs tests slow and  lots currently don't pass.  We don't have CI up for macOS getdeps at moment, so can address that separarately
```
./build/fbcode_builder/getdeps.py --allow-system-packages test --retry 0 --num-jobs=16 --src-dir=. sapling
```